### PR TITLE
Refactor `raftexample` using interfaces to better separate concerns

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -18,10 +18,10 @@ import (
 	pb "go.etcd.io/raft/v3/raftpb"
 )
 
-func applyToStore(ents []pb.Entry)    {}
-func sendMessages(msgs []pb.Message)  {}
-func saveStateToDisk(st pb.HardState) {}
-func saveToDisk(ents []pb.Entry)      {}
+func applyToStore(_ []pb.Entry)      {}
+func sendMessages(_ []pb.Message)    {}
+func saveStateToDisk(_ pb.HardState) {}
+func saveToDisk(_ []pb.Entry)        {}
 
 func ExampleNode() {
 	c := &Config{}

--- a/node_test.go
+++ b/node_test.go
@@ -1090,7 +1090,7 @@ type ignoreSizeHintMemStorage struct {
 	*MemoryStorage
 }
 
-func (s *ignoreSizeHintMemStorage) Entries(lo, hi uint64, maxSize uint64) ([]raftpb.Entry, error) {
+func (s *ignoreSizeHintMemStorage) Entries(lo, hi uint64, _ uint64) ([]raftpb.Entry, error) {
 	return s.MemoryStorage.Entries(lo, hi, math.MaxUint64)
 }
 

--- a/raftexample/etcdserverpb/raft_internal_stringer.go
+++ b/raftexample/etcdserverpb/raft_internal_stringer.go
@@ -78,6 +78,7 @@ type txnRequestStringer struct {
 	Request *TxnRequest
 }
 
+//nolint:revive
 func NewLoggableTxnRequest(request *TxnRequest) *txnRequestStringer {
 	return &txnRequestStringer{request}
 }
@@ -167,6 +168,7 @@ type loggablePutRequest struct {
 	IgnoreLease bool   `protobuf:"varint,6,opt,name=ignore_lease,proto3"`
 }
 
+//nolint:revive
 func NewLoggablePutRequest(request *PutRequest) *loggablePutRequest {
 	return &loggablePutRequest{
 		request.Key,

--- a/raftexample/fileutil/lock_linux.go
+++ b/raftexample/fileutil/lock_linux.go
@@ -1,0 +1,92 @@
+// Copyright 2016 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package fileutil
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// This used to call syscall.Flock() but that call fails with EBADF on NFS.
+// An alternative is lockf() which works on NFS but that call lets a process lock
+// the same file twice. Instead, use Linux's non-standard open file descriptor
+// locks which will block if the process already holds the file lock.
+
+var (
+	wrlck = syscall.Flock_t{
+		Type:   syscall.F_WRLCK,
+		Whence: int16(io.SeekStart),
+		Start:  0,
+		Len:    0,
+	}
+
+	linuxTryLockFile = flockTryLockFile
+	linuxLockFile    = flockLockFile
+)
+
+func init() {
+	// use open file descriptor locks if the system supports it
+	getlk := syscall.Flock_t{Type: syscall.F_RDLCK}
+	if err := syscall.FcntlFlock(0, unix.F_OFD_GETLK, &getlk); err == nil {
+		linuxTryLockFile = ofdTryLockFile
+		linuxLockFile = ofdLockFile
+	}
+}
+
+func TryLockFile(path string, flag int, perm os.FileMode) (*LockedFile, error) {
+	return linuxTryLockFile(path, flag, perm)
+}
+
+func ofdTryLockFile(path string, flag int, perm os.FileMode) (*LockedFile, error) {
+	f, err := os.OpenFile(path, flag, perm)
+	if err != nil {
+		return nil, fmt.Errorf("ofdTryLockFile failed to open %q (%v)", path, err)
+	}
+
+	flock := wrlck
+	if err = syscall.FcntlFlock(f.Fd(), unix.F_OFD_SETLK, &flock); err != nil {
+		f.Close()
+		if err == syscall.EWOULDBLOCK {
+			err = ErrLocked
+		}
+		return nil, err
+	}
+	return &LockedFile{f}, nil
+}
+
+func LockFile(path string, flag int, perm os.FileMode) (*LockedFile, error) {
+	return linuxLockFile(path, flag, perm)
+}
+
+func ofdLockFile(path string, flag int, perm os.FileMode) (*LockedFile, error) {
+	f, err := os.OpenFile(path, flag, perm)
+	if err != nil {
+		return nil, fmt.Errorf("ofdLockFile failed to open %q (%v)", path, err)
+	}
+
+	flock := wrlck
+	err = syscall.FcntlFlock(f.Fd(), unix.F_OFD_SETLKW, &flock)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	return &LockedFile{f}, nil
+}

--- a/raftexample/httpapi.go
+++ b/raftexample/httpapi.go
@@ -114,7 +114,9 @@ func (h *httpKVAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // serveHTTPKVAPI starts a key-value server with a GET/PUT API and listens.
-func serveHTTPKVAPI(kv KVStore, port int, confChangeC chan<- raftpb.ConfChange, errorC <-chan error) {
+func serveHTTPKVAPI(
+	kv KVStore, port int, confChangeC chan<- raftpb.ConfChange, done <-chan struct{},
+) {
 	srv := http.Server{
 		Addr: ":" + strconv.Itoa(port),
 		Handler: &httpKVAPI{
@@ -129,7 +131,6 @@ func serveHTTPKVAPI(kv KVStore, port int, confChangeC chan<- raftpb.ConfChange, 
 	}()
 
 	// exit when raft goes down
-	if err, ok := <-errorC; ok {
-		log.Fatal(err)
-	}
+	<-done
+	_ = srv.Close()
 }

--- a/raftexample/kvstore.go
+++ b/raftexample/kvstore.go
@@ -42,14 +42,17 @@ type kv struct {
 // applies the most recent snapshot (if any are available). The caller
 // must call `processCommits()` on the return value (normally, in a
 // goroutine) to make it start apply commits from raft to the state.
-func newKVStore(snapshotStorage SnapshotStorage, proposeC chan<- string) *kvstore {
+//
+// The second return value can be used as the finite state machine
+// that is driven by raft.
+func newKVStore(snapshotStorage SnapshotStorage, proposeC chan<- string) (*kvstore, kvfsm) {
 	s := &kvstore{
 		proposeC:        proposeC,
 		kvStore:         make(map[string]string),
 		snapshotStorage: snapshotStorage,
 	}
 	s.loadAndApplySnapshot()
-	return s
+	return s, kvfsm{kvs: s}
 }
 
 func (s *kvstore) Lookup(key string) (string, bool) {
@@ -65,23 +68,6 @@ func (s *kvstore) Propose(k string, v string) {
 		log.Fatal(err)
 	}
 	s.proposeC <- buf.String()
-}
-
-// processCommits() reads commits from `commitC` and applies them into
-// the kvStore map until that channel is closed.
-func (s *kvstore) processCommits(commitC <-chan *commit, errorC <-chan error) {
-	for commit := range commitC {
-		if commit == nil {
-			// This is a request that we load a snapshot.
-			s.loadAndApplySnapshot()
-			continue
-		}
-
-		s.applyCommits(commit)
-	}
-	if err, ok := <-errorC; ok {
-		log.Fatal(err)
-	}
 }
 
 // loadAndApplySnapshot load the most recent snapshot from the
@@ -134,4 +120,29 @@ func (s *kvstore) recoverFromSnapshot(snapshot []byte) error {
 	defer s.mu.Unlock()
 	s.kvStore = store
 	return nil
+}
+
+type kvfsm struct {
+	kvs *kvstore
+}
+
+func (fsm kvfsm) TakeSnapshot() ([]byte, error) {
+	return fsm.kvs.getSnapshot()
+}
+
+// ProcessCommits() reads commits from `commitC` and applies them into
+// the kvstore until that channel is closed.
+func (fsm kvfsm) ProcessCommits(commitC <-chan *commit, errorC <-chan error) {
+	for commit := range commitC {
+		if commit == nil {
+			// This is a request that we load a snapshot.
+			fsm.kvs.loadAndApplySnapshot()
+			continue
+		}
+
+		fsm.kvs.applyCommits(commit)
+	}
+	if err, ok := <-errorC; ok {
+		log.Fatal(err)
+	}
 }

--- a/raftexample/kvstore.go
+++ b/raftexample/kvstore.go
@@ -22,16 +22,13 @@ import (
 	"log"
 	"strings"
 	"sync"
-
-	"go.etcd.io/raft/v3/raftexample/snap"
 )
 
 // a key-value store backed by raft
 type kvstore struct {
-	proposeC        chan<- string // channel for proposing updates
-	mu              sync.RWMutex
-	kvStore         map[string]string // current committed key-value pairs
-	snapshotStorage SnapshotStorage
+	proposeC chan<- string // channel for proposing updates
+	mu       sync.RWMutex
+	kvStore  map[string]string // current committed key-value pairs
 }
 
 type kv struct {
@@ -39,18 +36,13 @@ type kv struct {
 	Val string
 }
 
-// newKVStore creates and returns a new `kvstore` and loads and
-// applies the most recent snapshot (if any are available). The caller
-// must call `processCommits()` on the return value (normally, in a
-// goroutine) to make it start apply commits from raft to the state.
-//
-// The second return value can be used as the finite state machine
-// that is driven by raft.
-func newKVStore(snapshotStorage SnapshotStorage, proposeC chan<- string) (*kvstore, kvfsm) {
+// newKVStore creates and returns a new `kvstore`. The second return
+// value can be used as the finite state machine that is driven by a
+// `raftNode`.
+func newKVStore(proposeC chan<- string) (*kvstore, kvfsm) {
 	s := &kvstore{
-		proposeC:        proposeC,
-		kvStore:         make(map[string]string),
-		snapshotStorage: snapshotStorage,
+		proposeC: proposeC,
+		kvStore:  make(map[string]string),
 	}
 	fsm := kvfsm{
 		kvs: s,
@@ -100,24 +92,6 @@ func (fsm kvfsm) RestoreSnapshot(snapshot []byte) error {
 	}
 	fsm.kvs.restoreFromSnapshot(store)
 	return nil
-}
-
-// LoadAndApplySnapshot loads the most recent snapshot from the
-// snapshot storage (if any) and applies it to the current state.
-func (fsm kvfsm) LoadAndApplySnapshot() {
-	snapshot, err := fsm.kvs.snapshotStorage.Load()
-	if err != nil {
-		if err == snap.ErrNoSnapshot {
-			// No snapshots available; do nothing.
-			return
-		}
-		log.Panic(err)
-	}
-
-	log.Printf("loading snapshot at term %d and index %d", snapshot.Metadata.Term, snapshot.Metadata.Index)
-	if err := fsm.RestoreSnapshot(snapshot.Data); err != nil {
-		log.Panic(err)
-	}
 }
 
 func (fsm kvfsm) TakeSnapshot() ([]byte, error) {

--- a/raftexample/kvstore.go
+++ b/raftexample/kvstore.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 
 	"go.etcd.io/raft/v3/raftexample/snap"
-	"go.etcd.io/raft/v3/raftpb"
 )
 
 // a key-value store backed by raft
@@ -73,6 +72,7 @@ func (s *kvstore) Propose(k string, v string) {
 func (s *kvstore) processCommits(commitC <-chan *commit, errorC <-chan error) {
 	for commit := range commitC {
 		if commit == nil {
+			// This is a request that we load a snapshot.
 			s.loadAndApplySnapshot()
 			continue
 		}
@@ -85,18 +85,20 @@ func (s *kvstore) processCommits(commitC <-chan *commit, errorC <-chan error) {
 }
 
 // loadAndApplySnapshot load the most recent snapshot from the
-// snapshot storage and applies it to the current state.
+// snapshot storage (if any) and applies it to the current state.
 func (s *kvstore) loadAndApplySnapshot() {
-	// signaled to load snapshot
-	snapshot, err := s.loadSnapshot()
+	snapshot, err := s.snapshotStorage.Load()
 	if err != nil {
+		if err == snap.ErrNoSnapshot {
+			// No snapshots available; do nothing.
+			return
+		}
 		log.Panic(err)
 	}
-	if snapshot != nil {
-		log.Printf("loading snapshot at term %d and index %d", snapshot.Metadata.Term, snapshot.Metadata.Index)
-		if err := s.recoverFromSnapshot(snapshot.Data); err != nil {
-			log.Panic(err)
-		}
+
+	log.Printf("loading snapshot at term %d and index %d", snapshot.Metadata.Term, snapshot.Metadata.Index)
+	if err := s.recoverFromSnapshot(snapshot.Data); err != nil {
+		log.Panic(err)
 	}
 }
 
@@ -121,17 +123,6 @@ func (s *kvstore) getSnapshot() ([]byte, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return json.Marshal(s.kvStore)
-}
-
-func (s *kvstore) loadSnapshot() (*raftpb.Snapshot, error) {
-	snapshot, err := s.snapshotStorage.Load()
-	if err == snap.ErrNoSnapshot {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	return snapshot, nil
 }
 
 func (s *kvstore) recoverFromSnapshot(snapshot []byte) error {

--- a/raftexample/kvstore.go
+++ b/raftexample/kvstore.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"encoding/json"
+	"fmt"
 	"log"
 	"strings"
 	"sync"
@@ -129,16 +130,17 @@ func (fsm kvfsm) TakeSnapshot() ([]byte, error) {
 // applyCommits decodes and applies each of the commits in `commit` to
 // the current state, then signals that it is done by closing
 // `commit.applyDoneC`.
-func (fsm kvfsm) applyCommits(commit *commit) {
+func (fsm kvfsm) applyCommits(commit *commit) error {
 	for _, data := range commit.data {
 		var dataKv kv
 		dec := gob.NewDecoder(bytes.NewBufferString(data))
 		if err := dec.Decode(&dataKv); err != nil {
-			log.Fatalf("raftexample: could not decode message (%v)", err)
+			return fmt.Errorf("could not decode message: %w", err)
 		}
 		fsm.kvs.set(dataKv.Key, dataKv.Val)
 	}
 	close(commit.applyDoneC)
+	return nil
 }
 
 // ProcessCommits() reads commits from `commitC` and applies them into
@@ -151,7 +153,9 @@ func (fsm kvfsm) ProcessCommits(commitC <-chan *commit, errorC <-chan error) {
 			continue
 		}
 
-		fsm.applyCommits(commit)
+		if err := fsm.applyCommits(commit); err != nil {
+			log.Fatalf("raftexample: %v", err)
+		}
 	}
 	if err, ok := <-errorC; ok {
 		log.Fatal(err)

--- a/raftexample/kvstore.go
+++ b/raftexample/kvstore.go
@@ -51,8 +51,11 @@ func newKVStore(snapshotStorage SnapshotStorage, proposeC chan<- string) (*kvsto
 		kvStore:         make(map[string]string),
 		snapshotStorage: snapshotStorage,
 	}
-	s.loadAndApplySnapshot()
-	return s, kvfsm{kvs: s}
+	fsm := kvfsm{
+		kvs: s,
+	}
+	fsm.LoadAndApplySnapshot()
+	return s, fsm
 }
 
 func (s *kvstore) Lookup(key string) (string, bool) {
@@ -70,10 +73,39 @@ func (s *kvstore) Propose(k string, v string) {
 	s.proposeC <- buf.String()
 }
 
-// loadAndApplySnapshot load the most recent snapshot from the
+// Set sets a single value. It should only be called by `kvfsm`.
+func (s *kvstore) set(k, v string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.kvStore[k] = v
+}
+
+func (s *kvstore) restoreFromSnapshot(store map[string]string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.kvStore = store
+}
+
+// kvfsm implements the `FSM` interface for the underlying `*kvstore`.
+type kvfsm struct {
+	kvs *kvstore
+}
+
+// RestoreSnapshot restores the current state of the KV store to the
+// value encoded in `snapshot`.
+func (fsm kvfsm) RestoreSnapshot(snapshot []byte) error {
+	var store map[string]string
+	if err := json.Unmarshal(snapshot, &store); err != nil {
+		return err
+	}
+	fsm.kvs.restoreFromSnapshot(store)
+	return nil
+}
+
+// LoadAndApplySnapshot loads the most recent snapshot from the
 // snapshot storage (if any) and applies it to the current state.
-func (s *kvstore) loadAndApplySnapshot() {
-	snapshot, err := s.snapshotStorage.Load()
+func (fsm kvfsm) LoadAndApplySnapshot() {
+	snapshot, err := fsm.kvs.snapshotStorage.Load()
 	if err != nil {
 		if err == snap.ErrNoSnapshot {
 			// No snapshots available; do nothing.
@@ -83,51 +115,30 @@ func (s *kvstore) loadAndApplySnapshot() {
 	}
 
 	log.Printf("loading snapshot at term %d and index %d", snapshot.Metadata.Term, snapshot.Metadata.Index)
-	if err := s.recoverFromSnapshot(snapshot.Data); err != nil {
+	if err := fsm.RestoreSnapshot(snapshot.Data); err != nil {
 		log.Panic(err)
 	}
+}
+
+func (fsm kvfsm) TakeSnapshot() ([]byte, error) {
+	fsm.kvs.mu.RLock()
+	defer fsm.kvs.mu.RUnlock()
+	return json.Marshal(fsm.kvs.kvStore)
 }
 
 // applyCommits decodes and applies each of the commits in `commit` to
 // the current state, then signals that it is done by closing
 // `commit.applyDoneC`.
-func (s *kvstore) applyCommits(commit *commit) {
+func (fsm kvfsm) applyCommits(commit *commit) {
 	for _, data := range commit.data {
 		var dataKv kv
 		dec := gob.NewDecoder(bytes.NewBufferString(data))
 		if err := dec.Decode(&dataKv); err != nil {
 			log.Fatalf("raftexample: could not decode message (%v)", err)
 		}
-		s.mu.Lock()
-		s.kvStore[dataKv.Key] = dataKv.Val
-		s.mu.Unlock()
+		fsm.kvs.set(dataKv.Key, dataKv.Val)
 	}
 	close(commit.applyDoneC)
-}
-
-func (s *kvstore) getSnapshot() ([]byte, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return json.Marshal(s.kvStore)
-}
-
-func (s *kvstore) recoverFromSnapshot(snapshot []byte) error {
-	var store map[string]string
-	if err := json.Unmarshal(snapshot, &store); err != nil {
-		return err
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.kvStore = store
-	return nil
-}
-
-type kvfsm struct {
-	kvs *kvstore
-}
-
-func (fsm kvfsm) TakeSnapshot() ([]byte, error) {
-	return fsm.kvs.getSnapshot()
 }
 
 // ProcessCommits() reads commits from `commitC` and applies them into
@@ -136,11 +147,11 @@ func (fsm kvfsm) ProcessCommits(commitC <-chan *commit, errorC <-chan error) {
 	for commit := range commitC {
 		if commit == nil {
 			// This is a request that we load a snapshot.
-			fsm.kvs.loadAndApplySnapshot()
+			fsm.LoadAndApplySnapshot()
 			continue
 		}
 
-		fsm.kvs.applyCommits(commit)
+		fsm.applyCommits(commit)
 	}
 	if err, ok := <-errorC; ok {
 		log.Fatal(err)

--- a/raftexample/kvstore.go
+++ b/raftexample/kvstore.go
@@ -127,10 +127,10 @@ func (fsm kvfsm) TakeSnapshot() ([]byte, error) {
 	return json.Marshal(fsm.kvs.kvStore)
 }
 
-// applyCommits decodes and applies each of the commits in `commit` to
+// ApplyCommits decodes and applies each of the commits in `commit` to
 // the current state, then signals that it is done by closing
 // `commit.applyDoneC`.
-func (fsm kvfsm) applyCommits(commit *commit) error {
+func (fsm kvfsm) ApplyCommits(commit *commit) error {
 	for _, data := range commit.data {
 		var dataKv kv
 		dec := gob.NewDecoder(bytes.NewBufferString(data))
@@ -153,7 +153,7 @@ func (fsm kvfsm) ProcessCommits(commitC <-chan *commit, errorC <-chan error) err
 			continue
 		}
 
-		if err := fsm.applyCommits(commit); err != nil {
+		if err := fsm.ApplyCommits(commit); err != nil {
 			return err
 		}
 	}

--- a/raftexample/kvstore.go
+++ b/raftexample/kvstore.go
@@ -141,23 +141,3 @@ func (fsm kvfsm) ApplyCommits(commit *commit) error {
 	close(commit.applyDoneC)
 	return nil
 }
-
-// ProcessCommits() reads commits from `commitC` and applies them into
-// the kvstore until that channel is closed.
-func (fsm kvfsm) ProcessCommits(commitC <-chan *commit, errorC <-chan error) error {
-	for commit := range commitC {
-		if commit == nil {
-			// This is a request that we load a snapshot.
-			fsm.LoadAndApplySnapshot()
-			continue
-		}
-
-		if err := fsm.ApplyCommits(commit); err != nil {
-			return err
-		}
-	}
-	if err, ok := <-errorC; ok {
-		return err
-	}
-	return nil
-}

--- a/raftexample/kvstore.go
+++ b/raftexample/kvstore.go
@@ -55,7 +55,6 @@ func newKVStore(snapshotStorage SnapshotStorage, proposeC chan<- string) (*kvsto
 	fsm := kvfsm{
 		kvs: s,
 	}
-	fsm.LoadAndApplySnapshot()
 	return s, fsm
 }
 

--- a/raftexample/kvstore.go
+++ b/raftexample/kvstore.go
@@ -39,18 +39,17 @@ type kv struct {
 	Val string
 }
 
-func newKVStore(
-	snapshotStorage SnapshotStorage,
-	proposeC chan<- string, commitC <-chan *commit, errorC <-chan error,
-) *kvstore {
+// newKVStore creates and returns a new `kvstore` and loads and
+// applies the most recent snapshot (if any are available). The caller
+// must call `processCommits()` on the return value (normally, in a
+// goroutine) to make it start apply commits from raft to the state.
+func newKVStore(snapshotStorage SnapshotStorage, proposeC chan<- string) *kvstore {
 	s := &kvstore{
 		proposeC:        proposeC,
 		kvStore:         make(map[string]string),
 		snapshotStorage: snapshotStorage,
 	}
 	s.loadAndApplySnapshot()
-	// read commits from raft into kvStore map until error
-	go s.readCommits(commitC, errorC)
 	return s
 }
 
@@ -69,7 +68,9 @@ func (s *kvstore) Propose(k string, v string) {
 	s.proposeC <- buf.String()
 }
 
-func (s *kvstore) readCommits(commitC <-chan *commit, errorC <-chan error) {
+// processCommits() reads commits from `commitC` and applies them into
+// the kvStore map until that channel is closed.
+func (s *kvstore) processCommits(commitC <-chan *commit, errorC <-chan error) {
 	for commit := range commitC {
 		if commit == nil {
 			s.loadAndApplySnapshot()

--- a/raftexample/kvstore.go
+++ b/raftexample/kvstore.go
@@ -145,7 +145,7 @@ func (fsm kvfsm) applyCommits(commit *commit) error {
 
 // ProcessCommits() reads commits from `commitC` and applies them into
 // the kvstore until that channel is closed.
-func (fsm kvfsm) ProcessCommits(commitC <-chan *commit, errorC <-chan error) {
+func (fsm kvfsm) ProcessCommits(commitC <-chan *commit, errorC <-chan error) error {
 	for commit := range commitC {
 		if commit == nil {
 			// This is a request that we load a snapshot.
@@ -154,10 +154,11 @@ func (fsm kvfsm) ProcessCommits(commitC <-chan *commit, errorC <-chan error) {
 		}
 
 		if err := fsm.applyCommits(commit); err != nil {
-			log.Fatalf("raftexample: %v", err)
+			return err
 		}
 	}
 	if err, ok := <-errorC; ok {
-		log.Fatal(err)
+		return err
 	}
+	return nil
 }

--- a/raftexample/kvstore.go
+++ b/raftexample/kvstore.go
@@ -48,16 +48,7 @@ func newKVStore(
 		kvStore:         make(map[string]string),
 		snapshotStorage: snapshotStorage,
 	}
-	snapshot, err := s.loadSnapshot()
-	if err != nil {
-		log.Panic(err)
-	}
-	if snapshot != nil {
-		log.Printf("loading snapshot at term %d and index %d", snapshot.Metadata.Term, snapshot.Metadata.Index)
-		if err := s.recoverFromSnapshot(snapshot.Data); err != nil {
-			log.Panic(err)
-		}
-	}
+	s.loadAndApplySnapshot()
 	// read commits from raft into kvStore map until error
 	go s.readCommits(commitC, errorC)
 	return s
@@ -81,35 +72,48 @@ func (s *kvstore) Propose(k string, v string) {
 func (s *kvstore) readCommits(commitC <-chan *commit, errorC <-chan error) {
 	for commit := range commitC {
 		if commit == nil {
-			// signaled to load snapshot
-			snapshot, err := s.loadSnapshot()
-			if err != nil {
-				log.Panic(err)
-			}
-			if snapshot != nil {
-				log.Printf("loading snapshot at term %d and index %d", snapshot.Metadata.Term, snapshot.Metadata.Index)
-				if err := s.recoverFromSnapshot(snapshot.Data); err != nil {
-					log.Panic(err)
-				}
-			}
+			s.loadAndApplySnapshot()
 			continue
 		}
 
-		for _, data := range commit.data {
-			var dataKv kv
-			dec := gob.NewDecoder(bytes.NewBufferString(data))
-			if err := dec.Decode(&dataKv); err != nil {
-				log.Fatalf("raftexample: could not decode message (%v)", err)
-			}
-			s.mu.Lock()
-			s.kvStore[dataKv.Key] = dataKv.Val
-			s.mu.Unlock()
-		}
-		close(commit.applyDoneC)
+		s.applyCommits(commit)
 	}
 	if err, ok := <-errorC; ok {
 		log.Fatal(err)
 	}
+}
+
+// loadAndApplySnapshot load the most recent snapshot from the
+// snapshot storage and applies it to the current state.
+func (s *kvstore) loadAndApplySnapshot() {
+	// signaled to load snapshot
+	snapshot, err := s.loadSnapshot()
+	if err != nil {
+		log.Panic(err)
+	}
+	if snapshot != nil {
+		log.Printf("loading snapshot at term %d and index %d", snapshot.Metadata.Term, snapshot.Metadata.Index)
+		if err := s.recoverFromSnapshot(snapshot.Data); err != nil {
+			log.Panic(err)
+		}
+	}
+}
+
+// applyCommits decodes and applies each of the commits in `commit` to
+// the current state, then signals that it is done by closing
+// `commit.applyDoneC`.
+func (s *kvstore) applyCommits(commit *commit) {
+	for _, data := range commit.data {
+		var dataKv kv
+		dec := gob.NewDecoder(bytes.NewBufferString(data))
+		if err := dec.Decode(&dataKv); err != nil {
+			log.Fatalf("raftexample: could not decode message (%v)", err)
+		}
+		s.mu.Lock()
+		s.kvStore[dataKv.Key] = dataKv.Val
+		s.mu.Unlock()
+	}
+	close(commit.applyDoneC)
 }
 
 func (s *kvstore) getSnapshot() ([]byte, error) {

--- a/raftexample/kvstore.go
+++ b/raftexample/kvstore.go
@@ -28,10 +28,10 @@ import (
 
 // a key-value store backed by raft
 type kvstore struct {
-	proposeC    chan<- string // channel for proposing updates
-	mu          sync.RWMutex
-	kvStore     map[string]string // current committed key-value pairs
-	snapshotter *snap.Snapshotter
+	proposeC        chan<- string // channel for proposing updates
+	mu              sync.RWMutex
+	kvStore         map[string]string // current committed key-value pairs
+	snapshotStorage SnapshotStorage
 }
 
 type kv struct {
@@ -39,8 +39,15 @@ type kv struct {
 	Val string
 }
 
-func newKVStore(snapshotter *snap.Snapshotter, proposeC chan<- string, commitC <-chan *commit, errorC <-chan error) *kvstore {
-	s := &kvstore{proposeC: proposeC, kvStore: make(map[string]string), snapshotter: snapshotter}
+func newKVStore(
+	snapshotStorage SnapshotStorage,
+	proposeC chan<- string, commitC <-chan *commit, errorC <-chan error,
+) *kvstore {
+	s := &kvstore{
+		proposeC:        proposeC,
+		kvStore:         make(map[string]string),
+		snapshotStorage: snapshotStorage,
+	}
 	snapshot, err := s.loadSnapshot()
 	if err != nil {
 		log.Panic(err)
@@ -112,7 +119,7 @@ func (s *kvstore) getSnapshot() ([]byte, error) {
 }
 
 func (s *kvstore) loadSnapshot() (*raftpb.Snapshot, error) {
-	snapshot, err := s.snapshotter.Load()
+	snapshot, err := s.snapshotStorage.Load()
 	if err == snap.ErrNoSnapshot {
 		return nil, nil
 	}

--- a/raftexample/kvstore_test.go
+++ b/raftexample/kvstore_test.go
@@ -22,19 +22,22 @@ import (
 func Test_kvstore_snapshot(t *testing.T) {
 	tm := map[string]string{"foo": "bar"}
 	s := &kvstore{kvStore: tm}
+	fsm := kvfsm{
+		kvs: s,
+	}
 
 	v, _ := s.Lookup("foo")
 	if v != "bar" {
 		t.Fatalf("foo has unexpected value, got %s", v)
 	}
 
-	data, err := s.getSnapshot()
+	data, err := fsm.TakeSnapshot()
 	if err != nil {
 		t.Fatal(err)
 	}
 	s.kvStore = nil
 
-	if err := s.recoverFromSnapshot(data); err != nil {
+	if err := fsm.RestoreSnapshot(data); err != nil {
 		t.Fatal(err)
 	}
 	v, _ = s.Lookup("foo")

--- a/raftexample/main.go
+++ b/raftexample/main.go
@@ -54,7 +54,11 @@ func main() {
 		proposeC, confChangeC,
 	)
 
-	go fsm.ProcessCommits(commitC, errorC)
+	go func() {
+		if err := fsm.ProcessCommits(commitC, errorC); err != nil {
+			log.Fatalf("raftexample: %v", err)
+		}
+	}()
 
 	// the key-value http handler will propose updates to raft
 	serveHTTPKVAPI(kvs, *kvport, confChangeC, errorC)

--- a/raftexample/main.go
+++ b/raftexample/main.go
@@ -23,7 +23,7 @@ import (
 
 func main() {
 	cluster := flag.String("cluster", "http://127.0.0.1:9021", "comma separated cluster peers")
-	id := flag.Int("id", 1, "node ID")
+	id := flag.Uint64("id", 1, "node ID")
 	kvport := flag.Int("port", 9121, "key-value server port")
 	join := flag.Bool("join", false, "join an existing cluster")
 	flag.Parse()

--- a/raftexample/main.go
+++ b/raftexample/main.go
@@ -46,15 +46,15 @@ func main() {
 		log.Fatalf("raftexample: %v", err)
 	}
 
-	kvs := newKVStore(snapshotStorage, proposeC)
+	kvs, fsm := newKVStore(snapshotStorage, proposeC)
 
 	commitC, errorC := startRaftNode(
 		*id, strings.Split(*cluster, ","), *join,
-		kvs.getSnapshot, snapshotStorage,
+		fsm, snapshotStorage,
 		proposeC, confChangeC,
 	)
 
-	go kvs.processCommits(commitC, errorC)
+	go fsm.ProcessCommits(commitC, errorC)
 
 	// the key-value http handler will propose updates to raft
 	serveHTTPKVAPI(kvs, *kvport, confChangeC, errorC)

--- a/raftexample/main.go
+++ b/raftexample/main.go
@@ -48,7 +48,7 @@ func main() {
 
 	kvs, fsm := newKVStore(proposeC)
 
-	rc, commitC, errorC := startRaftNode(
+	rc, commitC, _ := startRaftNode(
 		*id, strings.Split(*cluster, ","), *join,
 		fsm, snapshotStorage,
 		proposeC, confChangeC,
@@ -61,5 +61,5 @@ func main() {
 	}()
 
 	// the key-value http handler will propose updates to raft
-	serveHTTPKVAPI(kvs, *kvport, confChangeC, errorC)
+	serveHTTPKVAPI(kvs, *kvport, confChangeC, rc.Done())
 }

--- a/raftexample/main.go
+++ b/raftexample/main.go
@@ -36,11 +36,11 @@ func main() {
 	// raft provides a commit stream for the proposals from the http api
 	var kvs *kvstore
 	getSnapshot := func() ([]byte, error) { return kvs.getSnapshot() }
-	commitC, errorC, snapshotStorageReady := newRaftNode(
+	commitC, errorC, snapshotStorage := startRaftNode(
 		*id, strings.Split(*cluster, ","), *join, getSnapshot, proposeC, confChangeC,
 	)
 
-	kvs = newKVStore(<-snapshotStorageReady, proposeC, commitC, errorC)
+	kvs = newKVStore(snapshotStorage, proposeC, commitC, errorC)
 
 	// the key-value http handler will propose updates to raft
 	serveHTTPKVAPI(kvs, *kvport, confChangeC, errorC)

--- a/raftexample/main.go
+++ b/raftexample/main.go
@@ -46,7 +46,7 @@ func main() {
 		log.Fatalf("raftexample: %v", err)
 	}
 
-	kvs, fsm := newKVStore(snapshotStorage, proposeC)
+	kvs, fsm := newKVStore(proposeC)
 
 	rc, commitC, errorC := startRaftNode(
 		*id, strings.Split(*cluster, ","), *join,

--- a/raftexample/main.go
+++ b/raftexample/main.go
@@ -49,14 +49,14 @@ func main() {
 	kvs, fsm := newKVStore(snapshotStorage, proposeC)
 	fsm.LoadAndApplySnapshot()
 
-	commitC, errorC := startRaftNode(
+	rc, commitC, errorC := startRaftNode(
 		*id, strings.Split(*cluster, ","), *join,
 		fsm, snapshotStorage,
 		proposeC, confChangeC,
 	)
 
 	go func() {
-		if err := fsm.ProcessCommits(commitC, errorC); err != nil {
+		if err := rc.ProcessCommits(commitC, errorC); err != nil {
 			log.Fatalf("raftexample: %v", err)
 		}
 	}()

--- a/raftexample/main.go
+++ b/raftexample/main.go
@@ -47,6 +47,7 @@ func main() {
 	}
 
 	kvs, fsm := newKVStore(snapshotStorage, proposeC)
+	fsm.LoadAndApplySnapshot()
 
 	commitC, errorC := startRaftNode(
 		*id, strings.Split(*cluster, ","), *join,

--- a/raftexample/main.go
+++ b/raftexample/main.go
@@ -47,7 +47,6 @@ func main() {
 	}
 
 	kvs, fsm := newKVStore(snapshotStorage, proposeC)
-	fsm.LoadAndApplySnapshot()
 
 	rc, commitC, errorC := startRaftNode(
 		*id, strings.Split(*cluster, ","), *join,

--- a/raftexample/main.go
+++ b/raftexample/main.go
@@ -55,7 +55,7 @@ func main() {
 	)
 
 	go func() {
-		if err := rc.ProcessCommits(commitC, errorC); err != nil {
+		if err := rc.ProcessCommits(commitC); err != nil {
 			log.Fatalf("raftexample: %v", err)
 		}
 	}()

--- a/raftexample/main.go
+++ b/raftexample/main.go
@@ -48,14 +48,14 @@ func main() {
 
 	kvs, fsm := newKVStore(proposeC)
 
-	rc, commitC, _ := startRaftNode(
+	rc := startRaftNode(
 		*id, strings.Split(*cluster, ","), *join,
 		fsm, snapshotStorage,
 		proposeC, confChangeC,
 	)
 
 	go func() {
-		if err := rc.ProcessCommits(commitC); err != nil {
+		if err := rc.ProcessCommits(); err != nil {
 			log.Fatalf("raftexample: %v", err)
 		}
 	}()

--- a/raftexample/main.go
+++ b/raftexample/main.go
@@ -36,9 +36,11 @@ func main() {
 	// raft provides a commit stream for the proposals from the http api
 	var kvs *kvstore
 	getSnapshot := func() ([]byte, error) { return kvs.getSnapshot() }
-	commitC, errorC, snapshotterReady := newRaftNode(*id, strings.Split(*cluster, ","), *join, getSnapshot, proposeC, confChangeC)
+	commitC, errorC, snapshotStorageReady := newRaftNode(
+		*id, strings.Split(*cluster, ","), *join, getSnapshot, proposeC, confChangeC,
+	)
 
-	kvs = newKVStore(<-snapshotterReady, proposeC, commitC, errorC)
+	kvs = newKVStore(<-snapshotStorageReady, proposeC, commitC, errorC)
 
 	// the key-value http handler will propose updates to raft
 	serveHTTPKVAPI(kvs, *kvport, confChangeC, errorC)

--- a/raftexample/raft.go
+++ b/raftexample/raft.go
@@ -127,6 +127,14 @@ func newRaftNode(
 		snapshotStorageReady: make(chan SnapshotStorage, 1),
 		// rest of structure populated after WAL replay
 	}
+
+	snapshotLogger := zap.NewExample()
+	var err error
+	rc.snapshotStorage, err = newSnapshotStorage(snapshotLogger, rc.snapdir)
+	if err != nil {
+		log.Fatalf("raftexample: %v", err)
+	}
+
 	go rc.startRaft()
 	return commitC, errorC, rc.snapshotStorageReady
 }
@@ -288,13 +296,6 @@ func (rc *raftNode) writeError(err error) {
 }
 
 func (rc *raftNode) startRaft() {
-	snapshotLogger := zap.NewExample()
-	var err error
-	rc.snapshotStorage, err = newSnapshotStorage(snapshotLogger, rc.snapdir)
-	if err != nil {
-		log.Fatalf("raftexample: %v", err)
-	}
-
 	oldwal := wal.Exist(rc.waldir)
 	rc.wal = rc.replayWAL()
 

--- a/raftexample/raft.go
+++ b/raftexample/raft.go
@@ -100,6 +100,11 @@ type FSM interface {
 	// bytes that can be saved or loaded by a `SnapshotStorage`.
 	TakeSnapshot() ([]byte, error)
 
+	// RestoreSnapshot restores the finite state machine to the state
+	// represented by `snapshot` (which, in turn, was returned by
+	// `TakeSnapshot`).
+	RestoreSnapshot(snapshot []byte) error
+
 	// ProcessCommits reads committed updates (and requests to restore
 	// snapshots) from `commitC` and applies them to the finite state
 	// machine.

--- a/raftexample/raft.go
+++ b/raftexample/raft.go
@@ -150,6 +150,8 @@ func startRaftNode(
 		// rest of structure populated after WAL replay
 	}
 
+	rc.fsm.LoadAndApplySnapshot()
+
 	oldwal := wal.Exist(rc.waldir)
 	rc.wal = rc.replayWAL()
 

--- a/raftexample/raft.go
+++ b/raftexample/raft.go
@@ -65,8 +65,8 @@ type raftNode struct {
 	raftStorage *raft.MemoryStorage
 	wal         *wal.WAL
 
-	snapshotter      *snap.Snapshotter
-	snapshotterReady chan *snap.Snapshotter // signals when snapshotter is ready
+	snapshotStorage      SnapshotStorage
+	snapshotStorageReady chan SnapshotStorage // signals when snapshotStorage is ready
 
 	snapCount uint64
 	transport *rafthttp.Transport
@@ -77,6 +77,21 @@ type raftNode struct {
 	logger *zap.Logger
 }
 
+// SnapshotStorage is the interface that must be fulfilled by the
+// persistent storage for snapshots.
+type SnapshotStorage interface {
+	// SaveSnap saves `snapshot` to persistent storage.
+	SaveSnap(snapshot raftpb.Snapshot) error
+
+	// Load reads and returns the newest snapshot that is
+	// available.
+	Load() (*raftpb.Snapshot, error)
+
+	// LoadNewestAvailable loads the newest available snapshot
+	// whose term and index matches one of those in walSnaps.
+	LoadNewestAvailable(walSnaps []walpb.Snapshot) (*raftpb.Snapshot, error)
+}
+
 var defaultSnapshotCount uint64 = 10000
 
 // newRaftNode initiates a raft instance and returns a committed log entry
@@ -84,9 +99,10 @@ var defaultSnapshotCount uint64 = 10000
 // provided the proposal channel. All log entries are replayed over the
 // commit channel, followed by a nil message (to indicate the channel is
 // current), then new log entries. To shutdown, close proposeC and read errorC.
-func newRaftNode(id int, peers []string, join bool, getSnapshot func() ([]byte, error), proposeC <-chan string,
-	confChangeC <-chan raftpb.ConfChange) (<-chan *commit, <-chan error, <-chan *snap.Snapshotter) {
-
+func newRaftNode(
+	id int, peers []string, join bool, getSnapshot func() ([]byte, error), proposeC <-chan string,
+	confChangeC <-chan raftpb.ConfChange,
+) (<-chan *commit, <-chan error, <-chan SnapshotStorage) {
 	commitC := make(chan *commit)
 	errorC := make(chan error)
 
@@ -108,11 +124,11 @@ func newRaftNode(id int, peers []string, join bool, getSnapshot func() ([]byte, 
 
 		logger: zap.NewExample(),
 
-		snapshotterReady: make(chan *snap.Snapshotter, 1),
+		snapshotStorageReady: make(chan SnapshotStorage, 1),
 		// rest of structure populated after WAL replay
 	}
 	go rc.startRaft()
-	return commitC, errorC, rc.snapshotterReady
+	return commitC, errorC, rc.snapshotStorageReady
 }
 
 func (rc *raftNode) saveSnap(snap raftpb.Snapshot) error {
@@ -124,7 +140,7 @@ func (rc *raftNode) saveSnap(snap raftpb.Snapshot) error {
 	// save the snapshot file before writing the snapshot to the wal.
 	// This makes it possible for the snapshot file to become orphaned, but prevents
 	// a WAL snapshot entry from having no corresponding snapshot file.
-	if err := rc.snapshotter.SaveSnap(snap); err != nil {
+	if err := rc.snapshotStorage.SaveSnap(snap); err != nil {
 		return err
 	}
 	if err := rc.wal.SaveSnapshot(walSnap); err != nil {
@@ -206,7 +222,7 @@ func (rc *raftNode) loadSnapshot() *raftpb.Snapshot {
 		if err != nil {
 			log.Fatalf("raftexample: error listing snapshots (%v)", err)
 		}
-		snapshot, err := rc.snapshotter.LoadNewestAvailable(walSnaps)
+		snapshot, err := rc.snapshotStorage.LoadNewestAvailable(walSnaps)
 		if err != nil && err != snap.ErrNoSnapshot {
 			log.Fatalf("raftexample: error loading snapshot (%v)", err)
 		}
@@ -272,18 +288,18 @@ func (rc *raftNode) writeError(err error) {
 }
 
 func (rc *raftNode) startRaft() {
-	if !fileutil.Exist(rc.snapdir) {
-		if err := os.Mkdir(rc.snapdir, 0750); err != nil {
-			log.Fatalf("raftexample: cannot create dir for snapshot (%v)", err)
-		}
+	snapshotLogger := zap.NewExample()
+	var err error
+	rc.snapshotStorage, err = newSnapshotStorage(snapshotLogger, rc.snapdir)
+	if err != nil {
+		log.Fatalf("raftexample: %v", err)
 	}
-	rc.snapshotter = snap.New(zap.NewExample(), rc.snapdir)
 
 	oldwal := wal.Exist(rc.waldir)
 	rc.wal = rc.replayWAL()
 
 	// signal replay has finished
-	rc.snapshotterReady <- rc.snapshotter
+	rc.snapshotStorageReady <- rc.snapshotStorage
 
 	rpeers := make([]raft.Peer, len(rc.peers))
 	for i := range rpeers {
@@ -519,4 +535,13 @@ func (rc *raftNode) IsIDRemoved(_ uint64) bool   { return false }
 func (rc *raftNode) ReportUnreachable(id uint64) { rc.node.ReportUnreachable(id) }
 func (rc *raftNode) ReportSnapshot(id uint64, status raft.SnapshotStatus) {
 	rc.node.ReportSnapshot(id, status)
+}
+
+func newSnapshotStorage(lg *zap.Logger, dir string) (SnapshotStorage, error) {
+	if !fileutil.Exist(dir) {
+		if err := os.Mkdir(dir, 0750); err != nil {
+			return nil, fmt.Errorf("cannot create dir for snapshot: %w", err)
+		}
+	}
+	return snap.New(lg, dir), nil
 }

--- a/raftexample/raft.go
+++ b/raftexample/raft.go
@@ -105,6 +105,10 @@ type FSM interface {
 	// `TakeSnapshot`).
 	RestoreSnapshot(snapshot []byte) error
 
+	// LoadAndApplySnapshot loads the most recent snapshot from the
+	// snapshot storage (if any) and applies it to the current state.
+	LoadAndApplySnapshot()
+
 	// ApplyCommits applies the changes from `commit` to the finite
 	// state machine. `commit` is never `nil`. (By contrast, the
 	// commits that are handled by `ProcessCommits()` can be `nil` to

--- a/raftexample/raft.go
+++ b/raftexample/raft.go
@@ -49,6 +49,11 @@ type raftNode struct {
 	commitC     chan<- *commit           // entries committed to log (k,v)
 	errorC      chan<- error             // errors from raft session
 
+	// When serveChannels is done, `err` is set to any error and then
+	// `done` is closed.
+	err  error
+	done chan struct{}
+
 	id     uint64   // client ID for raft session
 	peers  []string // raft peer URLs
 	join   bool     // node is joining an existing cluster
@@ -130,6 +135,7 @@ func startRaftNode(
 		confChangeC:     confChangeC,
 		commitC:         commitC,
 		errorC:          errorC,
+		done:            make(chan struct{}),
 		id:              id,
 		peers:           peers,
 		join:            join,
@@ -176,7 +182,7 @@ func (rc *raftNode) loadAndApplySnapshot() {
 
 // ProcessCommits reads commits from `commitC` and applies them into
 // the kvstore until that channel is closed.
-func (rc *raftNode) ProcessCommits(commitC <-chan *commit, errorC <-chan error) error {
+func (rc *raftNode) ProcessCommits(commitC <-chan *commit) error {
 	for commit := range commitC {
 		if commit == nil {
 			// This is a request that we load a snapshot.
@@ -188,10 +194,25 @@ func (rc *raftNode) ProcessCommits(commitC <-chan *commit, errorC <-chan error) 
 			return err
 		}
 	}
-	if err, ok := <-errorC; ok {
-		return err
+	<-rc.done
+	return rc.err
+}
+
+// Done returns a channel that is closed when `rc` is done processing
+// requests.
+func (rc *raftNode) Done() <-chan struct{} {
+	return rc.done
+}
+
+// Err returns any error encountered while processing requests, or nil
+// if request processing is not yet done.
+func (rc *raftNode) Err() error {
+	select {
+	case <-rc.done:
+		return rc.err
+	default:
+		return nil
 	}
-	return nil
 }
 
 func (rc *raftNode) saveSnap(snap raftpb.Snapshot) error {
@@ -345,8 +366,10 @@ func (rc *raftNode) replayWAL() *wal.WAL {
 func (rc *raftNode) writeError(err error) {
 	rc.stopHTTP()
 	close(rc.commitC)
+	rc.err = err
 	rc.errorC <- err
 	close(rc.errorC)
+	close(rc.done)
 	rc.node.Stop()
 }
 
@@ -399,6 +422,7 @@ func (rc *raftNode) stop() {
 	rc.stopHTTP()
 	close(rc.commitC)
 	close(rc.errorC)
+	close(rc.done)
 	rc.node.Stop()
 }
 

--- a/raftexample/raft.go
+++ b/raftexample/raft.go
@@ -108,7 +108,7 @@ type FSM interface {
 	// ProcessCommits reads committed updates (and requests to restore
 	// snapshots) from `commitC` and applies them to the finite state
 	// machine.
-	ProcessCommits(commitC <-chan *commit, errorC <-chan error)
+	ProcessCommits(commitC <-chan *commit, errorC <-chan error) error
 }
 
 // startRaftNode initiates a raft instance and returns a committed log entry

--- a/raftexample/raft.go
+++ b/raftexample/raft.go
@@ -53,7 +53,6 @@ type raftNode struct {
 	peers       []string // raft peer URLs
 	join        bool     // node is joining an existing cluster
 	waldir      string   // path to WAL directory
-	snapdir     string   // path to snapshot directory
 	getSnapshot func() ([]byte, error)
 
 	confState     raftpb.ConfState
@@ -115,7 +114,6 @@ func startRaftNode(
 		peers:       peers,
 		join:        join,
 		waldir:      fmt.Sprintf("raftexample-%d", id),
-		snapdir:     fmt.Sprintf("raftexample-%d-snap", id),
 		getSnapshot: getSnapshot,
 		snapCount:   defaultSnapshotCount,
 		stopc:       make(chan struct{}),
@@ -129,7 +127,8 @@ func startRaftNode(
 
 	snapshotLogger := zap.NewExample()
 	var err error
-	rc.snapshotStorage, err = newSnapshotStorage(snapshotLogger, rc.snapdir)
+	snapdir := fmt.Sprintf("raftexample-%d-snap", id)
+	rc.snapshotStorage, err = newSnapshotStorage(snapshotLogger, snapdir)
 	if err != nil {
 		log.Fatalf("raftexample: %v", err)
 	}

--- a/raftexample/raft.go
+++ b/raftexample/raft.go
@@ -46,8 +46,8 @@ type commit struct {
 type raftNode struct {
 	proposeC    <-chan string            // proposed messages (k,v)
 	confChangeC <-chan raftpb.ConfChange // proposed cluster config changes
-	commitC     chan<- *commit           // entries committed to log (k,v)
-	errorC      chan<- error             // errors from raft session
+	commitC     chan *commit             // entries committed to log (k,v)
+	errorC      chan error               // errors from raft session
 
 	// When serveChannels is done, `err` is set to any error and then
 	// `done` is closed.
@@ -126,7 +126,7 @@ func startRaftNode(
 	id uint64, peers []string, join bool,
 	fsm FSM, snapshotStorage SnapshotStorage,
 	proposeC <-chan string, confChangeC <-chan raftpb.ConfChange,
-) (*raftNode, <-chan *commit, <-chan error) {
+) *raftNode {
 	commitC := make(chan *commit)
 	errorC := make(chan error)
 
@@ -159,7 +159,7 @@ func startRaftNode(
 
 	go rc.startRaft(oldwal)
 
-	return rc, commitC, errorC
+	return rc
 }
 
 // loadAndApplySnapshot loads the most recent snapshot from the
@@ -182,8 +182,8 @@ func (rc *raftNode) loadAndApplySnapshot() {
 
 // ProcessCommits reads commits from `commitC` and applies them into
 // the kvstore until that channel is closed.
-func (rc *raftNode) ProcessCommits(commitC <-chan *commit) error {
-	for commit := range commitC {
+func (rc *raftNode) ProcessCommits() error {
+	for commit := range rc.commitC {
 		if commit == nil {
 			// This is a request that we load a snapshot.
 			rc.loadAndApplySnapshot()

--- a/raftexample/raft.go
+++ b/raftexample/raft.go
@@ -105,6 +105,12 @@ type FSM interface {
 	// `TakeSnapshot`).
 	RestoreSnapshot(snapshot []byte) error
 
+	// ApplyCommits applies the changes from `commit` to the finite
+	// state machine. `commit` is never `nil`. (By contrast, the
+	// commits that are handled by `ProcessCommits()` can be `nil` to
+	// signal that a snapshot should be loaded.)
+	ApplyCommits(commit *commit) error
+
 	// ProcessCommits reads committed updates (and requests to restore
 	// snapshots) from `commitC` and applies them to the finite state
 	// machine.

--- a/raftexample/raft.go
+++ b/raftexample/raft.go
@@ -515,7 +515,7 @@ func (rc *raftNode) serveRaft() {
 func (rc *raftNode) Process(ctx context.Context, m raftpb.Message) error {
 	return rc.node.Step(ctx, m)
 }
-func (rc *raftNode) IsIDRemoved(id uint64) bool  { return false }
+func (rc *raftNode) IsIDRemoved(_ uint64) bool   { return false }
 func (rc *raftNode) ReportUnreachable(id uint64) { rc.node.ReportUnreachable(id) }
 func (rc *raftNode) ReportSnapshot(id uint64, status raft.SnapshotStatus) {
 	rc.node.ReportSnapshot(id, status)

--- a/raftexample/raftexample_test.go
+++ b/raftexample/raftexample_test.go
@@ -31,21 +31,27 @@ import (
 	"go.etcd.io/raft/v3/raftpb"
 )
 
-func getSnapshotFn() (func() ([]byte, error), <-chan struct{}) {
-	snapshotTriggeredC := make(chan struct{})
-	return func() ([]byte, error) {
-		snapshotTriggeredC <- struct{}{}
-		return nil, nil
-	}, snapshotTriggeredC
+type snapshotWatcher struct {
+	C chan struct{}
+}
+
+func (sw snapshotWatcher) ProcessCommits(commitC <-chan *commit, errorC <-chan error) {
+	_, _ = commitC, errorC
+	panic("not implemented")
+}
+
+func (sw snapshotWatcher) TakeSnapshot() ([]byte, error) {
+	sw.C <- struct{}{}
+	return nil, nil
 }
 
 type cluster struct {
-	peers              []string
-	commitC            []<-chan *commit
-	errorC             []<-chan error
-	proposeC           []chan string
-	confChangeC        []chan raftpb.ConfChange
-	snapshotTriggeredC []<-chan struct{}
+	peers            []string
+	commitC          []<-chan *commit
+	errorC           []<-chan error
+	proposeC         []chan string
+	confChangeC      []chan raftpb.ConfChange
+	snapshotWatchers []snapshotWatcher
 }
 
 // newCluster creates a cluster of n nodes
@@ -56,12 +62,12 @@ func newCluster(n int) *cluster {
 	}
 
 	clus := &cluster{
-		peers:              peers,
-		commitC:            make([]<-chan *commit, len(peers)),
-		errorC:             make([]<-chan error, len(peers)),
-		proposeC:           make([]chan string, len(peers)),
-		confChangeC:        make([]chan raftpb.ConfChange, len(peers)),
-		snapshotTriggeredC: make([]<-chan struct{}, len(peers)),
+		peers:            peers,
+		commitC:          make([]<-chan *commit, len(peers)),
+		errorC:           make([]<-chan error, len(peers)),
+		proposeC:         make([]chan string, len(peers)),
+		confChangeC:      make([]chan raftpb.ConfChange, len(peers)),
+		snapshotWatchers: make([]snapshotWatcher, len(peers)),
 	}
 
 	for i := range clus.peers {
@@ -71,8 +77,10 @@ func newCluster(n int) *cluster {
 		os.RemoveAll(snapdir)
 		clus.proposeC[i] = make(chan string, 1)
 		clus.confChangeC[i] = make(chan raftpb.ConfChange, 1)
-		fn, snapshotTriggeredC := getSnapshotFn()
-		clus.snapshotTriggeredC[i] = snapshotTriggeredC
+		snapshotWatcher := snapshotWatcher{
+			C: make(chan struct{}),
+		}
+		clus.snapshotWatchers[i] = snapshotWatcher
 
 		snapshotLogger := zap.NewExample()
 		snapshotStorage, err := newSnapshotStorage(snapshotLogger, snapdir)
@@ -82,7 +90,7 @@ func newCluster(n int) *cluster {
 
 		clus.commitC[i], clus.errorC[i] = startRaftNode(
 			id, clus.peers, false,
-			fn, snapshotStorage,
+			snapshotWatcher, snapshotStorage,
 			clus.proposeC[i], clus.confChangeC[i],
 		)
 	}
@@ -206,15 +214,15 @@ func TestPutAndGetKeyValue(t *testing.T) {
 		log.Fatalf("raftexample: %v", err)
 	}
 
-	kvs := newKVStore(snapshotStorage, proposeC)
+	kvs, fsm := newKVStore(snapshotStorage, proposeC)
 
 	commitC, errorC := startRaftNode(
 		id, clusters, false,
-		kvs.getSnapshot, snapshotStorage,
+		fsm, snapshotStorage,
 		proposeC, confChangeC,
 	)
 
-	go kvs.processCommits(commitC, errorC)
+	go fsm.ProcessCommits(commitC, errorC)
 
 	srv := httptest.NewServer(&httpKVAPI{
 		store:       kvs,
@@ -327,10 +335,10 @@ func TestSnapshot(t *testing.T) {
 	c := <-clus.commitC[0]
 
 	select {
-	case <-clus.snapshotTriggeredC[0]:
+	case <-clus.snapshotWatchers[0].C:
 		t.Fatalf("snapshot triggered before applying done")
 	default:
 	}
 	close(c.applyDoneC)
-	<-clus.snapshotTriggeredC[0]
+	<-clus.snapshotWatchers[0].C
 }

--- a/raftexample/raftexample_test.go
+++ b/raftexample/raftexample_test.go
@@ -68,7 +68,7 @@ func newCluster(n int) *cluster {
 		clus.confChangeC[i] = make(chan raftpb.ConfChange, 1)
 		fn, snapshotTriggeredC := getSnapshotFn()
 		clus.snapshotTriggeredC[i] = snapshotTriggeredC
-		clus.commitC[i], clus.errorC[i], _ = newRaftNode(
+		clus.commitC[i], clus.errorC[i], _ = startRaftNode(
 			i+1, clus.peers, false, fn, clus.proposeC[i], clus.confChangeC[i],
 		)
 	}
@@ -186,9 +186,9 @@ func TestPutAndGetKeyValue(t *testing.T) {
 
 	var kvs *kvstore
 	getSnapshot := func() ([]byte, error) { return kvs.getSnapshot() }
-	commitC, errorC, snapshotStorageReady := newRaftNode(1, clusters, false, getSnapshot, proposeC, confChangeC)
+	commitC, errorC, snapshotStorage := startRaftNode(1, clusters, false, getSnapshot, proposeC, confChangeC)
 
-	kvs = newKVStore(<-snapshotStorageReady, proposeC, commitC, errorC)
+	kvs = newKVStore(snapshotStorage, proposeC, commitC, errorC)
 
 	srv := httptest.NewServer(&httpKVAPI{
 		store:       kvs,
@@ -258,7 +258,7 @@ func TestAddNewNode(t *testing.T) {
 	confChangeC := make(chan raftpb.ConfChange)
 	defer close(confChangeC)
 
-	newRaftNode(4, append(clus.peers, newNodeURL), true, nil, proposeC, confChangeC)
+	startRaftNode(4, append(clus.peers, newNodeURL), true, nil, proposeC, confChangeC)
 
 	go func() {
 		proposeC <- "foo"

--- a/raftexample/raftexample_test.go
+++ b/raftexample/raftexample_test.go
@@ -32,30 +32,24 @@ import (
 )
 
 type peer struct {
-	commitC         <-chan *commit
-	errorC          <-chan error
-	proposeC        chan string
-	confChangeC     chan raftpb.ConfChange
-	snapshotWatcher snapshotWatcher
+	commitC     <-chan *commit
+	errorC      <-chan error
+	proposeC    chan string
+	confChangeC chan raftpb.ConfChange
+	fsm         FSM
 }
 
-type snapshotWatcher struct {
-	C chan struct{}
+type nullFSM struct{}
+
+func (nullFSM) ProcessCommits(_ <-chan *commit, _ <-chan error) {
 }
 
-func (sw snapshotWatcher) ProcessCommits(commitC <-chan *commit, errorC <-chan error) {
-	_, _ = commitC, errorC
-	panic("not implemented")
-}
-
-func (sw snapshotWatcher) TakeSnapshot() ([]byte, error) {
-	sw.C <- struct{}{}
+func (nullFSM) TakeSnapshot() ([]byte, error) {
 	return nil, nil
 }
 
-func (sw snapshotWatcher) RestoreSnapshot(snapshot []byte) error {
-	_ = snapshot
-	panic("not implemented")
+func (nullFSM) RestoreSnapshot(_ []byte) error {
+	return nil
 }
 
 type cluster struct {
@@ -64,28 +58,26 @@ type cluster struct {
 }
 
 // newCluster creates a cluster of n nodes
-func newCluster(n int) *cluster {
+func newCluster(fsms ...FSM) *cluster {
 	clus := cluster{
-		peerNames: make([]string, 0, n),
-		peers:     make([]*peer, 0, n),
+		peerNames: make([]string, 0, len(fsms)),
+		peers:     make([]*peer, 0, len(fsms)),
 	}
-	for i := 0; i < n; i++ {
+	for i := range fsms {
 		clus.peerNames = append(clus.peerNames, fmt.Sprintf("http://127.0.0.1:%d", 10000+i))
 	}
 
-	for i := 0; i < n; i++ {
+	for i, fsm := range fsms {
 		id := uint64(i + 1)
 		peer := peer{
 			proposeC:    make(chan string, 1),
 			confChangeC: make(chan raftpb.ConfChange, 1),
+			fsm:         fsm,
 		}
+
 		snapdir := fmt.Sprintf("raftexample-%d-snap", id)
 		os.RemoveAll(fmt.Sprintf("raftexample-%d", id))
 		os.RemoveAll(snapdir)
-		snapshotWatcher := snapshotWatcher{
-			C: make(chan struct{}),
-		}
-		peer.snapshotWatcher = snapshotWatcher
 
 		snapshotLogger := zap.NewExample()
 		snapshotStorage, err := newSnapshotStorage(snapshotLogger, snapdir)
@@ -95,7 +87,7 @@ func newCluster(n int) *cluster {
 
 		peer.commitC, peer.errorC = startRaftNode(
 			id, clus.peerNames, false,
-			snapshotWatcher, snapshotStorage,
+			peer.fsm, snapshotStorage,
 			peer.proposeC, peer.confChangeC,
 		)
 		clus.peers = append(clus.peers, &peer)
@@ -137,7 +129,7 @@ func (clus *cluster) closeNoErrors(t *testing.T) {
 // TestProposeOnCommit starts three nodes and feeds commits back into the proposal
 // channel. The intent is to ensure blocking on a proposal won't block raft progress.
 func TestProposeOnCommit(t *testing.T) {
-	clus := newCluster(3)
+	clus := newCluster(nullFSM{}, nullFSM{}, nullFSM{})
 	defer clus.closeNoErrors(t)
 
 	donec := make(chan struct{})
@@ -180,7 +172,7 @@ func TestProposeOnCommit(t *testing.T) {
 
 // TestCloseProposerBeforeReplay tests closing the producer before raft starts.
 func TestCloseProposerBeforeReplay(t *testing.T) {
-	clus := newCluster(1)
+	clus := newCluster(nullFSM{})
 	// close before replay so raft never starts
 	defer clus.closeNoErrors(t)
 }
@@ -188,7 +180,7 @@ func TestCloseProposerBeforeReplay(t *testing.T) {
 // TestCloseProposerInflight tests closing the producer while
 // committed messages are being published to the client.
 func TestCloseProposerInflight(t *testing.T) {
-	clus := newCluster(1)
+	clus := newCluster(nullFSM{})
 	defer clus.closeNoErrors(t)
 
 	var wg sync.WaitGroup
@@ -281,7 +273,7 @@ func TestPutAndGetKeyValue(t *testing.T) {
 
 // TestAddNewNode tests adding new node to the existing cluster.
 func TestAddNewNode(t *testing.T) {
-	clus := newCluster(3)
+	clus := newCluster(nullFSM{}, nullFSM{}, nullFSM{})
 	defer clus.closeNoErrors(t)
 
 	id := uint64(4)
@@ -327,6 +319,16 @@ func TestAddNewNode(t *testing.T) {
 	}
 }
 
+type snapshotWatcher struct {
+	nullFSM
+	C chan struct{}
+}
+
+func (sw snapshotWatcher) TakeSnapshot() ([]byte, error) {
+	sw.C <- struct{}{}
+	return nil, nil
+}
+
 func TestSnapshot(t *testing.T) {
 	prevDefaultSnapshotCount := defaultSnapshotCount
 	prevSnapshotCatchUpEntriesN := snapshotCatchUpEntriesN
@@ -337,7 +339,9 @@ func TestSnapshot(t *testing.T) {
 		snapshotCatchUpEntriesN = prevSnapshotCatchUpEntriesN
 	}()
 
-	clus := newCluster(3)
+	sw := snapshotWatcher{C: make(chan struct{})}
+
+	clus := newCluster(sw, nullFSM{}, nullFSM{})
 	defer clus.closeNoErrors(t)
 
 	go func() {
@@ -347,10 +351,10 @@ func TestSnapshot(t *testing.T) {
 	c := <-clus.peers[0].commitC
 
 	select {
-	case <-clus.peers[0].snapshotWatcher.C:
+	case <-sw.C:
 		t.Fatalf("snapshot triggered before applying done")
 	default:
 	}
 	close(c.applyDoneC)
-	<-clus.peers[0].snapshotWatcher.C
+	<-sw.C
 }

--- a/raftexample/raftexample_test.go
+++ b/raftexample/raftexample_test.go
@@ -224,7 +224,6 @@ func TestPutAndGetKeyValue(t *testing.T) {
 	}
 
 	kvs, fsm := newKVStore(snapshotStorage, proposeC)
-	fsm.LoadAndApplySnapshot()
 
 	node, commitC, errorC := startRaftNode(
 		id, clusters, false,
@@ -316,7 +315,7 @@ func TestAddNewNode(t *testing.T) {
 
 	startRaftNode(
 		id, append(clus.peerNames, newNodeURL), true,
-		nil, snapshotStorage,
+		nullFSM{}, snapshotStorage,
 		proposeC, confChangeC,
 	)
 

--- a/raftexample/raftexample_test.go
+++ b/raftexample/raftexample_test.go
@@ -34,7 +34,6 @@ import (
 type peer struct {
 	node        *raftNode
 	commitC     <-chan *commit
-	errorC      <-chan error
 	proposeC    chan string
 	confChangeC chan raftpb.ConfChange
 	fsm         FSM
@@ -87,7 +86,7 @@ func newCluster(fsms ...FSM) *cluster {
 			log.Fatalf("raftexample: %v", err)
 		}
 
-		peer.node, peer.commitC, peer.errorC = startRaftNode(
+		peer.node, peer.commitC, _ = startRaftNode(
 			id, clus.peerNames, false,
 			peer.fsm, snapshotStorage,
 			peer.proposeC, peer.confChangeC,
@@ -135,49 +134,88 @@ func (clus *cluster) closeNoErrors(t *testing.T) {
 	t.Log("closing cluster [done]")
 }
 
+type feedbackFSM struct {
+	nullFSM
+	peer     *peer
+	id       int
+	reEcho   int
+	expected int
+	received int
+}
+
+func newFeedbackFSM(id int, reEcho int, expected int) *feedbackFSM {
+	return &feedbackFSM{
+		id:       id,
+		reEcho:   reEcho,
+		expected: expected,
+	}
+}
+
+func (fsm *feedbackFSM) ApplyCommits(commit *commit) error {
+	for _, msg := range commit.data {
+		var originator, source, index int
+		if n, err := fmt.Sscanf(msg, "foo%d-%d-%d", &originator, &source, &index); err != nil || n != 3 {
+			panic(err)
+		}
+		if fsm.reEcho > 0 {
+			fsm.peer.proposeC <- fmt.Sprintf("foo%d-%d-%d", originator, fsm.id, index+1)
+			fsm.reEcho--
+		}
+
+		fsm.received++
+		if fsm.received == fsm.expected {
+			close(fsm.peer.proposeC)
+		}
+	}
+
+	close(commit.applyDoneC)
+
+	return nil
+}
+
 // TestProposeOnCommit starts three nodes and feeds commits back into the proposal
 // channel. The intent is to ensure blocking on a proposal won't block raft progress.
 func TestProposeOnCommit(t *testing.T) {
-	clus := newCluster(nullFSM{}, nullFSM{}, nullFSM{})
-	defer clus.closeNoErrors(t)
+	// We generate one proposal for each node to kick things off, then
+	// each node "echos" back the first 99 commits that it receives.
+	// So the total number of commits that each node expects to see is
+	// 300.
+	fsms := []*feedbackFSM{
+		newFeedbackFSM(1, 99, 300),
+		newFeedbackFSM(2, 99, 300),
+		newFeedbackFSM(3, 99, 300),
+	}
+	clus := newCluster(fsms[0], fsms[1], fsms[2])
+	for i := range fsms {
+		fsms[i].peer = clus.peers[i]
+	}
+	defer clus.Cleanup()
 
-	donec := make(chan struct{})
-	for _, peer := range clus.peers {
-		peer := peer
-		// feedback for "n" committed entries, then update donec
+	var wg sync.WaitGroup
+	for _, fsm := range fsms {
+		fsm := fsm
+		wg.Add(1)
 		go func() {
-			proposeC := peer.proposeC
-			for n := 0; n < 100; n++ {
-				c, ok := <-peer.commitC
-				if !ok {
-					proposeC = nil
-				}
-				select {
-				case proposeC <- c.data[0]:
-					continue
-				case <-peer.node.Done():
-					if err := peer.node.Err(); err != nil {
-						t.Errorf("peer error (%v)", err)
-					}
-				}
-			}
-			donec <- struct{}{}
-			//nolint:revive
-			for range peer.commitC {
-				// Acknowledge the rest of the commits (including
-				// those from other nodes) without feeding them back
-				// in so that raft can finish.
+			defer wg.Done()
+			if err := fsm.peer.node.ProcessCommits(fsm.peer.commitC); err != nil {
+				t.Error("ProcessCommits returned error", err)
 			}
 		}()
 
 		// Trigger the whole cascade by sending one message per node:
+		wg.Add(1)
 		go func() {
-			peer.proposeC <- "foo"
+			defer wg.Done()
+			fsm.peer.proposeC <- fmt.Sprintf("foo%d-%d-%d", fsm.id, fsm.id, 0)
 		}()
 	}
 
-	for range clus.peers {
-		<-donec
+	wg.Wait()
+
+	for _, fsm := range fsms {
+		if fsm.received != fsm.expected {
+			t.Errorf("node %d received %d commits (expected %d)", fsm.id, fsm.received, fsm.expected)
+		}
 	}
 }
 

--- a/raftexample/raftexample_test.go
+++ b/raftexample/raftexample_test.go
@@ -222,14 +222,14 @@ func TestPutAndGetKeyValue(t *testing.T) {
 
 	kvs, fsm := newKVStore(proposeC)
 
-	node, commitC, errorC := startRaftNode(
+	node, commitC, _ := startRaftNode(
 		id, clusters, false,
 		fsm, snapshotStorage,
 		proposeC, confChangeC,
 	)
 
 	go func() {
-		if err := node.ProcessCommits(commitC, errorC); err != nil {
+		if err := node.ProcessCommits(commitC); err != nil {
 			log.Fatalf("raftexample: %v", err)
 		}
 	}()

--- a/raftexample/raftexample_test.go
+++ b/raftexample/raftexample_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 type peer struct {
+	node        *raftNode
 	commitC     <-chan *commit
 	errorC      <-chan error
 	proposeC    chan string
@@ -40,10 +41,6 @@ type peer struct {
 }
 
 type nullFSM struct{}
-
-func (nullFSM) ProcessCommits(_ <-chan *commit, _ <-chan error) error {
-	return nil
-}
 
 func (nullFSM) TakeSnapshot() ([]byte, error) {
 	return nil, nil
@@ -93,7 +90,7 @@ func newCluster(fsms ...FSM) *cluster {
 			log.Fatalf("raftexample: %v", err)
 		}
 
-		peer.commitC, peer.errorC = startRaftNode(
+		peer.node, peer.commitC, peer.errorC = startRaftNode(
 			id, clus.peerNames, false,
 			peer.fsm, snapshotStorage,
 			peer.proposeC, peer.confChangeC,
@@ -229,14 +226,14 @@ func TestPutAndGetKeyValue(t *testing.T) {
 	kvs, fsm := newKVStore(snapshotStorage, proposeC)
 	fsm.LoadAndApplySnapshot()
 
-	commitC, errorC := startRaftNode(
+	node, commitC, errorC := startRaftNode(
 		id, clusters, false,
 		fsm, snapshotStorage,
 		proposeC, confChangeC,
 	)
 
 	go func() {
-		if err := fsm.ProcessCommits(commitC, errorC); err != nil {
+		if err := node.ProcessCommits(commitC, errorC); err != nil {
 			log.Fatalf("raftexample: %v", err)
 		}
 	}()

--- a/raftexample/raftexample_test.go
+++ b/raftexample/raftexample_test.go
@@ -50,9 +50,6 @@ func (nullFSM) RestoreSnapshot(_ []byte) error {
 	return nil
 }
 
-func (nullFSM) LoadAndApplySnapshot() {
-}
-
 func (nullFSM) ApplyCommits(_ *commit) error {
 	return nil
 }
@@ -223,7 +220,7 @@ func TestPutAndGetKeyValue(t *testing.T) {
 		log.Fatalf("raftexample: %v", err)
 	}
 
-	kvs, fsm := newKVStore(snapshotStorage, proposeC)
+	kvs, fsm := newKVStore(proposeC)
 
 	node, commitC, errorC := startRaftNode(
 		id, clusters, false,

--- a/raftexample/raftexample_test.go
+++ b/raftexample/raftexample_test.go
@@ -18,12 +18,15 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"sync"
 	"testing"
 	"time"
+
+	"go.uber.org/zap"
 
 	"go.etcd.io/raft/v3/raftpb"
 )
@@ -63,14 +66,24 @@ func newCluster(n int) *cluster {
 
 	for i := range clus.peers {
 		id := uint64(i + 1)
+		snapdir := fmt.Sprintf("raftexample-%d-snap", id)
 		os.RemoveAll(fmt.Sprintf("raftexample-%d", id))
-		os.RemoveAll(fmt.Sprintf("raftexample-%d-snap", id))
+		os.RemoveAll(snapdir)
 		clus.proposeC[i] = make(chan string, 1)
 		clus.confChangeC[i] = make(chan raftpb.ConfChange, 1)
 		fn, snapshotTriggeredC := getSnapshotFn()
 		clus.snapshotTriggeredC[i] = snapshotTriggeredC
-		clus.commitC[i], clus.errorC[i], _ = startRaftNode(
-			id, clus.peers, false, fn, clus.proposeC[i], clus.confChangeC[i],
+
+		snapshotLogger := zap.NewExample()
+		snapshotStorage, err := newSnapshotStorage(snapshotLogger, snapdir)
+		if err != nil {
+			log.Fatalf("raftexample: %v", err)
+		}
+
+		clus.commitC[i], clus.errorC[i] = startRaftNode(
+			id, clus.peers, false,
+			fn, snapshotStorage,
+			clus.proposeC[i], clus.confChangeC[i],
 		)
 	}
 
@@ -187,7 +200,20 @@ func TestPutAndGetKeyValue(t *testing.T) {
 
 	var kvs *kvstore
 	getSnapshot := func() ([]byte, error) { return kvs.getSnapshot() }
-	commitC, errorC, snapshotStorage := startRaftNode(1, clusters, false, getSnapshot, proposeC, confChangeC)
+
+	id := uint64(1)
+	snapshotLogger := zap.NewExample()
+	snapdir := fmt.Sprintf("raftexample-%d-snap", id)
+	snapshotStorage, err := newSnapshotStorage(snapshotLogger, snapdir)
+	if err != nil {
+		log.Fatalf("raftexample: %v", err)
+	}
+
+	commitC, errorC := startRaftNode(
+		id, clusters, false,
+		getSnapshot, snapshotStorage,
+		proposeC, confChangeC,
+	)
 
 	kvs = newKVStore(snapshotStorage, proposeC, commitC, errorC)
 
@@ -239,17 +265,19 @@ func TestAddNewNode(t *testing.T) {
 	clus := newCluster(3)
 	defer clus.closeNoErrors(t)
 
+	id := uint64(4)
+	snapdir := fmt.Sprintf("raftexample-%d-snap", id)
 	os.RemoveAll("raftexample-4")
-	os.RemoveAll("raftexample-4-snap")
+	os.RemoveAll(snapdir)
 	defer func() {
 		os.RemoveAll("raftexample-4")
-		os.RemoveAll("raftexample-4-snap")
+		os.RemoveAll(snapdir)
 	}()
 
 	newNodeURL := "http://127.0.0.1:10004"
 	clus.confChangeC[0] <- raftpb.ConfChange{
 		Type:    raftpb.ConfChangeAddNode,
-		NodeID:  4,
+		NodeID:  id,
 		Context: []byte(newNodeURL),
 	}
 
@@ -259,7 +287,17 @@ func TestAddNewNode(t *testing.T) {
 	confChangeC := make(chan raftpb.ConfChange)
 	defer close(confChangeC)
 
-	startRaftNode(4, append(clus.peers, newNodeURL), true, nil, proposeC, confChangeC)
+	snapshotLogger := zap.NewExample()
+	snapshotStorage, err := newSnapshotStorage(snapshotLogger, snapdir)
+	if err != nil {
+		log.Fatalf("raftexample: %v", err)
+	}
+
+	startRaftNode(
+		id, append(clus.peers, newNodeURL), true,
+		nil, snapshotStorage,
+		proposeC, confChangeC,
+	)
 
 	go func() {
 		proposeC <- "foo"

--- a/raftexample/raftexample_test.go
+++ b/raftexample/raftexample_test.go
@@ -110,7 +110,8 @@ func (clus *cluster) Close() (err error) {
 		}()
 		close(peer.proposeC)
 		// wait for channel to close
-		if erri := <-peer.errorC; erri != nil {
+		<-peer.node.Done()
+		if erri := peer.node.Err(); erri != nil {
 			err = erri
 		}
 		// clean intermediates

--- a/raftexample/raftexample_test.go
+++ b/raftexample/raftexample_test.go
@@ -149,8 +149,10 @@ func TestProposeOnCommit(t *testing.T) {
 				select {
 				case proposeC <- c.data[0]:
 					continue
-				case err := <-peer.errorC:
-					t.Errorf("eC message (%v)", err)
+				case <-peer.node.Done():
+					if err := peer.node.Err(); err != nil {
+						t.Errorf("peer error (%v)", err)
+					}
 				}
 			}
 			donec <- struct{}{}

--- a/raftexample/raftexample_test.go
+++ b/raftexample/raftexample_test.go
@@ -41,7 +41,8 @@ type peer struct {
 
 type nullFSM struct{}
 
-func (nullFSM) ProcessCommits(_ <-chan *commit, _ <-chan error) {
+func (nullFSM) ProcessCommits(_ <-chan *commit, _ <-chan error) error {
+	return nil
 }
 
 func (nullFSM) TakeSnapshot() ([]byte, error) {
@@ -226,7 +227,11 @@ func TestPutAndGetKeyValue(t *testing.T) {
 		proposeC, confChangeC,
 	)
 
-	go fsm.ProcessCommits(commitC, errorC)
+	go func() {
+		if err := fsm.ProcessCommits(commitC, errorC); err != nil {
+			log.Fatalf("raftexample: %v", err)
+		}
+	}()
 
 	srv := httptest.NewServer(&httpKVAPI{
 		store:       kvs,

--- a/raftexample/raftexample_test.go
+++ b/raftexample/raftexample_test.go
@@ -62,14 +62,15 @@ func newCluster(n int) *cluster {
 	}
 
 	for i := range clus.peers {
-		os.RemoveAll(fmt.Sprintf("raftexample-%d", i+1))
-		os.RemoveAll(fmt.Sprintf("raftexample-%d-snap", i+1))
+		id := uint64(i + 1)
+		os.RemoveAll(fmt.Sprintf("raftexample-%d", id))
+		os.RemoveAll(fmt.Sprintf("raftexample-%d-snap", id))
 		clus.proposeC[i] = make(chan string, 1)
 		clus.confChangeC[i] = make(chan raftpb.ConfChange, 1)
 		fn, snapshotTriggeredC := getSnapshotFn()
 		clus.snapshotTriggeredC[i] = snapshotTriggeredC
 		clus.commitC[i], clus.errorC[i], _ = startRaftNode(
-			i+1, clus.peers, false, fn, clus.proposeC[i], clus.confChangeC[i],
+			id, clus.peers, false, fn, clus.proposeC[i], clus.confChangeC[i],
 		)
 	}
 

--- a/raftexample/raftexample_test.go
+++ b/raftexample/raftexample_test.go
@@ -53,6 +53,9 @@ func (nullFSM) RestoreSnapshot(_ []byte) error {
 	return nil
 }
 
+func (nullFSM) LoadAndApplySnapshot() {
+}
+
 func (nullFSM) ApplyCommits(_ *commit) error {
 	return nil
 }
@@ -224,6 +227,7 @@ func TestPutAndGetKeyValue(t *testing.T) {
 	}
 
 	kvs, fsm := newKVStore(snapshotStorage, proposeC)
+	fsm.LoadAndApplySnapshot()
 
 	commitC, errorC := startRaftNode(
 		id, clusters, false,

--- a/raftexample/raftexample_test.go
+++ b/raftexample/raftexample_test.go
@@ -68,7 +68,9 @@ func newCluster(n int) *cluster {
 		clus.confChangeC[i] = make(chan raftpb.ConfChange, 1)
 		fn, snapshotTriggeredC := getSnapshotFn()
 		clus.snapshotTriggeredC[i] = snapshotTriggeredC
-		clus.commitC[i], clus.errorC[i], _ = newRaftNode(i+1, clus.peers, false, fn, clus.proposeC[i], clus.confChangeC[i])
+		clus.commitC[i], clus.errorC[i], _ = newRaftNode(
+			i+1, clus.peers, false, fn, clus.proposeC[i], clus.confChangeC[i],
+		)
 	}
 
 	return clus
@@ -184,9 +186,9 @@ func TestPutAndGetKeyValue(t *testing.T) {
 
 	var kvs *kvstore
 	getSnapshot := func() ([]byte, error) { return kvs.getSnapshot() }
-	commitC, errorC, snapshotterReady := newRaftNode(1, clusters, false, getSnapshot, proposeC, confChangeC)
+	commitC, errorC, snapshotStorageReady := newRaftNode(1, clusters, false, getSnapshot, proposeC, confChangeC)
 
-	kvs = newKVStore(<-snapshotterReady, proposeC, commitC, errorC)
+	kvs = newKVStore(<-snapshotStorageReady, proposeC, commitC, errorC)
 
 	srv := httptest.NewServer(&httpKVAPI{
 		store:       kvs,

--- a/raftexample/raftexample_test.go
+++ b/raftexample/raftexample_test.go
@@ -53,6 +53,10 @@ func (nullFSM) RestoreSnapshot(_ []byte) error {
 	return nil
 }
 
+func (nullFSM) ApplyCommits(_ *commit) error {
+	return nil
+}
+
 type cluster struct {
 	peerNames []string
 	peers     []*peer

--- a/raftexample/raftexample_test.go
+++ b/raftexample/raftexample_test.go
@@ -157,12 +157,13 @@ func TestProposeOnCommit(t *testing.T) {
 			donec <- struct{}{}
 			//nolint:revive
 			for range cC {
-				// acknowledge the commits from other nodes so
-				// raft continues to make progress
+				// Acknowledge the rest of the commits (including
+				// those from other nodes) without feeding them back
+				// in so that raft can finish.
 			}
 		}(clus.proposeC[i], clus.commitC[i], clus.errorC[i])
 
-		// one message feedback per node
+		// Trigger the whole cascade by sending one message per node:
 		go func(i int) { clus.proposeC[i] <- "foo" }(i)
 	}
 

--- a/raftexample/raftexample_test.go
+++ b/raftexample/raftexample_test.go
@@ -45,6 +45,11 @@ func (sw snapshotWatcher) TakeSnapshot() ([]byte, error) {
 	return nil, nil
 }
 
+func (sw snapshotWatcher) RestoreSnapshot(snapshot []byte) error {
+	_ = snapshot
+	panic("not implemented")
+}
+
 type cluster struct {
 	peers            []string
 	commitC          []<-chan *commit

--- a/raftexample/raftexample_test.go
+++ b/raftexample/raftexample_test.go
@@ -98,9 +98,17 @@ func newCluster(fsms ...FSM) *cluster {
 	return &clus
 }
 
+// Cleanup cleans up temporary files used by the test cluster.
+func (clus *cluster) Cleanup() {
+	for i := range clus.peers {
+		os.RemoveAll(fmt.Sprintf("raftexample-%d", i+1))
+		os.RemoveAll(fmt.Sprintf("raftexample-%d-snap", i+1))
+	}
+}
+
 // Close closes all cluster nodes and returns an error if any failed.
 func (clus *cluster) Close() (err error) {
-	for i, peer := range clus.peers {
+	for _, peer := range clus.peers {
 		peer := peer
 		go func() {
 			//nolint:revive
@@ -114,10 +122,8 @@ func (clus *cluster) Close() (err error) {
 		if erri := peer.node.Err(); erri != nil {
 			err = erri
 		}
-		// clean intermediates
-		os.RemoveAll(fmt.Sprintf("raftexample-%d", i+1))
-		os.RemoveAll(fmt.Sprintf("raftexample-%d-snap", i+1))
 	}
+	clus.Cleanup()
 	return err
 }
 

--- a/raftexample/raftexample_test.go
+++ b/raftexample/raftexample_test.go
@@ -31,6 +31,14 @@ import (
 	"go.etcd.io/raft/v3/raftpb"
 )
 
+type peer struct {
+	commitC         <-chan *commit
+	errorC          <-chan error
+	proposeC        chan string
+	confChangeC     chan raftpb.ConfChange
+	snapshotWatcher snapshotWatcher
+}
+
 type snapshotWatcher struct {
 	C chan struct{}
 }
@@ -51,41 +59,33 @@ func (sw snapshotWatcher) RestoreSnapshot(snapshot []byte) error {
 }
 
 type cluster struct {
-	peers            []string
-	commitC          []<-chan *commit
-	errorC           []<-chan error
-	proposeC         []chan string
-	confChangeC      []chan raftpb.ConfChange
-	snapshotWatchers []snapshotWatcher
+	peerNames []string
+	peers     []*peer
 }
 
 // newCluster creates a cluster of n nodes
 func newCluster(n int) *cluster {
-	peers := make([]string, n)
-	for i := range peers {
-		peers[i] = fmt.Sprintf("http://127.0.0.1:%d", 10000+i)
+	clus := cluster{
+		peerNames: make([]string, 0, n),
+		peers:     make([]*peer, 0, n),
+	}
+	for i := 0; i < n; i++ {
+		clus.peerNames = append(clus.peerNames, fmt.Sprintf("http://127.0.0.1:%d", 10000+i))
 	}
 
-	clus := &cluster{
-		peers:            peers,
-		commitC:          make([]<-chan *commit, len(peers)),
-		errorC:           make([]<-chan error, len(peers)),
-		proposeC:         make([]chan string, len(peers)),
-		confChangeC:      make([]chan raftpb.ConfChange, len(peers)),
-		snapshotWatchers: make([]snapshotWatcher, len(peers)),
-	}
-
-	for i := range clus.peers {
+	for i := 0; i < n; i++ {
 		id := uint64(i + 1)
+		peer := peer{
+			proposeC:    make(chan string, 1),
+			confChangeC: make(chan raftpb.ConfChange, 1),
+		}
 		snapdir := fmt.Sprintf("raftexample-%d-snap", id)
 		os.RemoveAll(fmt.Sprintf("raftexample-%d", id))
 		os.RemoveAll(snapdir)
-		clus.proposeC[i] = make(chan string, 1)
-		clus.confChangeC[i] = make(chan raftpb.ConfChange, 1)
 		snapshotWatcher := snapshotWatcher{
 			C: make(chan struct{}),
 		}
-		clus.snapshotWatchers[i] = snapshotWatcher
+		peer.snapshotWatcher = snapshotWatcher
 
 		snapshotLogger := zap.NewExample()
 		snapshotStorage, err := newSnapshotStorage(snapshotLogger, snapdir)
@@ -93,28 +93,30 @@ func newCluster(n int) *cluster {
 			log.Fatalf("raftexample: %v", err)
 		}
 
-		clus.commitC[i], clus.errorC[i] = startRaftNode(
-			id, clus.peers, false,
+		peer.commitC, peer.errorC = startRaftNode(
+			id, clus.peerNames, false,
 			snapshotWatcher, snapshotStorage,
-			clus.proposeC[i], clus.confChangeC[i],
+			peer.proposeC, peer.confChangeC,
 		)
+		clus.peers = append(clus.peers, &peer)
 	}
 
-	return clus
+	return &clus
 }
 
 // Close closes all cluster nodes and returns an error if any failed.
 func (clus *cluster) Close() (err error) {
-	for i := range clus.peers {
-		go func(i int) {
+	for i, peer := range clus.peers {
+		peer := peer
+		go func() {
 			//nolint:revive
-			for range clus.commitC[i] {
+			for range peer.commitC {
 				// drain pending commits
 			}
-		}(i)
-		close(clus.proposeC[i])
+		}()
+		close(peer.proposeC)
 		// wait for channel to close
-		if erri := <-clus.errorC[i]; erri != nil {
+		if erri := <-peer.errorC; erri != nil {
 			err = erri
 		}
 		// clean intermediates
@@ -139,32 +141,36 @@ func TestProposeOnCommit(t *testing.T) {
 	defer clus.closeNoErrors(t)
 
 	donec := make(chan struct{})
-	for i := range clus.peers {
+	for _, peer := range clus.peers {
+		peer := peer
 		// feedback for "n" committed entries, then update donec
-		go func(pC chan<- string, cC <-chan *commit, eC <-chan error) {
+		go func() {
+			proposeC := peer.proposeC
 			for n := 0; n < 100; n++ {
-				c, ok := <-cC
+				c, ok := <-peer.commitC
 				if !ok {
-					pC = nil
+					proposeC = nil
 				}
 				select {
-				case pC <- c.data[0]:
+				case proposeC <- c.data[0]:
 					continue
-				case err := <-eC:
+				case err := <-peer.errorC:
 					t.Errorf("eC message (%v)", err)
 				}
 			}
 			donec <- struct{}{}
 			//nolint:revive
-			for range cC {
+			for range peer.commitC {
 				// Acknowledge the rest of the commits (including
 				// those from other nodes) without feeding them back
 				// in so that raft can finish.
 			}
-		}(clus.proposeC[i], clus.commitC[i], clus.errorC[i])
+		}()
 
 		// Trigger the whole cascade by sending one message per node:
-		go func(i int) { clus.proposeC[i] <- "foo" }(i)
+		go func() {
+			peer.proposeC <- "foo"
+		}()
 	}
 
 	for range clus.peers {
@@ -191,12 +197,12 @@ func TestCloseProposerInflight(t *testing.T) {
 	// some inflight ops
 	go func() {
 		defer wg.Done()
-		clus.proposeC[0] <- "foo"
-		clus.proposeC[0] <- "bar"
+		clus.peers[0].proposeC <- "foo"
+		clus.peers[0].proposeC <- "bar"
 	}()
 
 	// wait for one message
-	if c, ok := <-clus.commitC[0]; !ok || c.data[0] != "foo" {
+	if c, ok := <-clus.peers[0].commitC; !ok || c.data[0] != "foo" {
 		t.Fatalf("Commit failed")
 	}
 
@@ -288,7 +294,7 @@ func TestAddNewNode(t *testing.T) {
 	}()
 
 	newNodeURL := "http://127.0.0.1:10004"
-	clus.confChangeC[0] <- raftpb.ConfChange{
+	clus.peers[0].confChangeC <- raftpb.ConfChange{
 		Type:    raftpb.ConfChangeAddNode,
 		NodeID:  id,
 		Context: []byte(newNodeURL),
@@ -307,7 +313,7 @@ func TestAddNewNode(t *testing.T) {
 	}
 
 	startRaftNode(
-		id, append(clus.peers, newNodeURL), true,
+		id, append(clus.peerNames, newNodeURL), true,
 		nil, snapshotStorage,
 		proposeC, confChangeC,
 	)
@@ -316,7 +322,7 @@ func TestAddNewNode(t *testing.T) {
 		proposeC <- "foo"
 	}()
 
-	if c, ok := <-clus.commitC[0]; !ok || c.data[0] != "foo" {
+	if c, ok := <-clus.peers[0].commitC; !ok || c.data[0] != "foo" {
 		t.Fatalf("Commit failed")
 	}
 }
@@ -335,16 +341,16 @@ func TestSnapshot(t *testing.T) {
 	defer clus.closeNoErrors(t)
 
 	go func() {
-		clus.proposeC[0] <- "foo"
+		clus.peers[0].proposeC <- "foo"
 	}()
 
-	c := <-clus.commitC[0]
+	c := <-clus.peers[0].commitC
 
 	select {
-	case <-clus.snapshotWatchers[0].C:
+	case <-clus.peers[0].snapshotWatcher.C:
 		t.Fatalf("snapshot triggered before applying done")
 	default:
 	}
 	close(c.applyDoneC)
-	<-clus.snapshotWatchers[0].C
+	<-clus.peers[0].snapshotWatcher.C
 }

--- a/raftexample/raftexample_test.go
+++ b/raftexample/raftexample_test.go
@@ -78,6 +78,7 @@ func newCluster(n int) *cluster {
 func (clus *cluster) Close() (err error) {
 	for i := range clus.peers {
 		go func(i int) {
+			//nolint:revive
 			for range clus.commitC[i] {
 				// drain pending commits
 			}
@@ -125,6 +126,7 @@ func TestProposeOnCommit(t *testing.T) {
 				}
 			}
 			donec <- struct{}{}
+			//nolint:revive
 			for range cC {
 				// acknowledge the commits from other nodes so
 				// raft continues to make progress

--- a/raftexample/transport/sockopt_unix.go
+++ b/raftexample/transport/sockopt_unix.go
@@ -22,13 +22,13 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func setReusePort(network, address string, conn syscall.RawConn) error {
+func setReusePort(_, _ string, conn syscall.RawConn) error {
 	return conn.Control(func(fd uintptr) {
 		syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, unix.SO_REUSEPORT, 1)
 	})
 }
 
-func setReuseAddress(network, address string, conn syscall.RawConn) error {
+func setReuseAddress(_, _ string, conn syscall.RawConn) error {
 	return conn.Control(func(fd uintptr) {
 		syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, unix.SO_REUSEADDR, 1)
 	})

--- a/raftexample/verify/verify.go
+++ b/raftexample/verify/verify.go
@@ -20,12 +20,15 @@ import (
 	"strings"
 )
 
+//nolint:revive
 const ENV_VERIFY = "ETCD_VERIFY"
 
 type VerificationType string
 
 const (
-	ENV_VERIFY_VALUE_ALL    VerificationType = "all"
+	//nolint:revive
+	ENV_VERIFY_VALUE_ALL VerificationType = "all"
+	//nolint:revive
 	ENV_VERIFY_VALUE_ASSERT VerificationType = "assert"
 )
 

--- a/raftexample/wal/version.go
+++ b/raftexample/wal/version.go
@@ -32,6 +32,8 @@ import (
 
 // ReadWALVersion reads remaining entries from opened WAL and returns struct
 // that implements schema.WAL interface.
+//
+//nolint:revive
 func ReadWALVersion(w *WAL) (*walVersion, error) {
 	_, _, ents, err := w.ReadAll()
 	if err != nil {

--- a/rafttest/interaction_env_handler_campaign.go
+++ b/rafttest/interaction_env_handler_campaign.go
@@ -26,6 +26,6 @@ func (env *InteractionEnv) handleCampaign(t *testing.T, d datadriven.TestData) e
 }
 
 // Campaign the node at the given index.
-func (env *InteractionEnv) Campaign(t *testing.T, idx int) error {
+func (env *InteractionEnv) Campaign(_ *testing.T, idx int) error {
 	return env.Nodes[idx].Campaign()
 }

--- a/rafttest/interaction_env_handler_log_level.go
+++ b/rafttest/interaction_env_handler_log_level.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cockroachdb/datadriven"
 )
 
-func (env *InteractionEnv) handleLogLevel(t *testing.T, d datadriven.TestData) error {
+func (env *InteractionEnv) handleLogLevel(_ *testing.T, d datadriven.TestData) error {
 	return env.LogLevel(d.CmdArgs[0].Key)
 }
 

--- a/rawnode_test.go
+++ b/rawnode_test.go
@@ -37,7 +37,7 @@ type rawNodeAdapter struct {
 var _ Node = (*rawNodeAdapter)(nil)
 
 // TransferLeadership is to test when node specifies lead, which is pointless, can just be filled in.
-func (a *rawNodeAdapter) TransferLeadership(ctx context.Context, lead, transferee uint64) {
+func (a *rawNodeAdapter) TransferLeadership(_ context.Context, _, transferee uint64) {
 	a.RawNode.TransferLeader(transferee)
 }
 


### PR DESCRIPTION
This is a re-roll of https://github.com/etcd-io/etcd/pull/15471 on top of https://github.com/etcd-io/raft/pull/67. It is almost identical to the original PR, with the following exceptions:

* The changes have been adapted to apply against the files in this repository instead of `etcd-io/etc`, and directory `raftexample` instead of `config/raftexample`.
* It starts with two preparatory commits to get `go build -o bin/raftexample ./raftexample`, `go test -race ./raftexample/...`, and `golangci-lint run` running without errors on Linux. (Those tests also run cleanly against every subsequent in this patch series.)
* A few things have been changed to keep the linter happy.

For convenience, the following top-level explanation of the changes is copied from https://github.com/etcd-io/etcd/pull/15471:

I come to etcd by way of evaluating `go.etcd.io/raft` for use in a project. When I saw that there was a sample application [`raftexample`](https://github.com/etcd-io/etcd/tree/main/contrib/raftexample) showing how to use the module, I started reading it, hoping that this would make it obvious what components I would have to implement to use raft in my own application.

But unfortunately, it wasn't easy to figure that out from the source code of `raftexample`. True, it provides a nice end-to-end example. Also, `raftNode` is a fairly nice abstraction, showing how to deal with the channels going into and coming out of the raft library. But I didn't find the interface between `raftNode` and the "application code" super transparent. For example,

* It is not obvious what features the `Snapshotter` must provide.
* It's hard to see the boundary between the raft code and the finite state machine being driven by it. `kvstore` is the FSM, but it also does things like read straight out of raft-managed channels and interact directly with the snapshotter.
* `httpKVAPI` contains a pointer to the whole `kvstore`, even though it really only interacts with its "public" interface, `Propose()` and `Lookup()`.
* The design forces an awkward initialization step, where `main()` creates a `getSnaphost` function that closes over an initialized variable (`kvs`) then passes that function into `newRaftNode()`. That function returns a `shapshotterReady <-chan *snap.Snapshotter` channel from which `main()` reads a `Snapshotter`. It was unclear how much of this was essential complexity and how much could be avoided. (It turns out that most of this complexity can be avoided.)
* `newRaftNode()` returns `commitC`, which is handed on to `newKVStore()` and read from a goroutine in that type. It seems like it would be simpler for `raftNode` to read from `commitC` and invoke `kvstore` methods to trigger commits.
* `newRaftNode()` returns `errorC`, to which it writes an error if there is a problem. But multiple pieces of code try to read from that channel, and the semantics of Go channels make it indeterminate which one will discover that there was an error. (In general, error reporting is somewhat inconsistent.)

This PR consists of a series of refactorings that attempt to fix a bunch of the problems listed above:

* It introduces a few interfaces and uses them to better separate concerns:
    * `SnapshotStorage` represents permanent storage for snapshots. It only needs to know how to read and write them:
        ```
        type SnapshotStorage interface {
            SaveSnap(snapshot raftpb.Snapshot) error
            Load() (*raftpb.Snapshot, error)
            LoadNewestAvailable(walSnaps []walpb.Snapshot) (*raftpb.Snapshot, error)
        }
        ```
    * `FSM` represents the finite state machine that `raftNode` is able to drive. It only has to know how to take and restore snapshots and to apply commits:
        ```
        type FSM interface {
            TakeSnapshot() ([]byte, error)
            RestoreSnapshot(snapshot []byte) error
            ApplyCommits(commit *commit) error
        }
        ```
    * `KVStore` represents the interface that `httpKVAPI` uses to interact with the key-value store. Note that this interface only exposes application-level concepts and doesn't really expose anything about raft, but internally it has to know how to serialize its calls into log entries that can be managed by raft:
        ```
        type KVStore interface {
            Propose(k, v string)
            Lookup(k string) (string, bool)
        }
        ```

* `kvstore` now presents a `KVStore` face to `httpKVAPI` and a `FSM` face to `raftNode`, but itself is now a passive type (no internal goroutines).

* Now `raftNode` implements more of the raft data flows internally; in particular, its `ProcessCommits()` method reads commits from `commitC` and applies them to the `kvstore` via the `FSM` interface.

* Now `main()` creates the snapshotter and passes it to `raftNode`. This eliminates the complexity of `snapshotterReady`.

* `raftNode` now has `Done()` and `Err()` methods (replacing the `errorC` channel) that the caller can use to find out when it is done and whether it experienced any errors.

I think these changes make the code easier to read, and more importantly, make it easier for the reader to figure out would they would have to change to use the raft module within their own application, even if that application doesn't happen to be a key-value store.

This is a long patch series, but each commit is a self-contained step, meant to be readable/reviewable independently, and the tests pass after each commit. I'd be happy to break it up into multiple smaller PRs if that is preferable.

Along the way I fixed a couple of other minor problems, such as the ambiguity about error reporting mentioned above, and in the strange `TestProposeOnCommit()` test. See the commit messages for more information.

I only changed code within `raftexample`. But within that package, I have changed some internal interfaces. I assume that since this is just demonstration code, there are no backwards-compatibility promises made about this package. For the same reason, I have introduced some interfaces where there were none before, which will probably decrease performance very slightly and maybe force a few more allocations. Again, my goal was to make the code easier to understand, and I assume that preserving uncompromising performance is a lower priority than clarity.

I think that some further refactoring would be nice, to better delineate the interfaces between `raftNode` and the write-ahead log, and perhaps between `raftNode` and the transport layer. But I'll wait to see how this PR is received before proceeding.

I hope this is helpful!

/cc @Elbehery
